### PR TITLE
Fix write_tb_crys

### DIFF
--- a/src/TB.jl
+++ b/src/TB.jl
@@ -815,8 +815,8 @@ function write_tb_crys(filename, tbc::tb_crys)
     addelement!(root, "background_charge_correction", string(tbc.background_charge_correction))
     addelement!(root, "eden", arr2str(tbc.eden))
 
-    addelement!(root, "efermi", string(tbc.energy))
-    addelement!(root, "energy", string(tbc.efermi))
+    addelement!(root, "efermi", string(tbc.efermi))
+    addelement!(root, "energy", string(tbc.energy))
 
     
     tightbinding = ElementNode("tightbinding")


### PR DESCRIPTION
In `write_tb_crys()`, the parameters `efermi` and `energy` are swapped.